### PR TITLE
TFP-5904 tillate mor uttak 12 uker før fødsel

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/regelmodell/opptjeningsperiode/fp/FastsettSkjæringsdatoMorFødsel.java
+++ b/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/regelmodell/opptjeningsperiode/fp/FastsettSkjæringsdatoMorFødsel.java
@@ -28,7 +28,7 @@ public class FastsettSkjæringsdatoMorFødsel extends LeafSpecification<Opptjeni
         var senesteUttakFørTermin = terminDato.map(t -> t.minus(regelmodell.getRegelParametre().morSenesteUttakFørTerminPeriode()));
         var hendelsesDato = regelmodell.getGrunnlag().hendelsesDato();
         // Strengt tatt ikke i lov eller rundskriv, men er etablert og gammel praksis med 3 uker før dersom termindato mangler.
-        var tidligsteUttakFørHendelseSedvane = hendelsesDato.minus(regelmodell.getRegelParametre().morSenesteUttakFørTerminPeriode());
+        var tidligsteUttakFørHendelseSedvane = hendelsesDato.minus(regelmodell.getRegelParametre().morTidligsteUttakFørTerminPeriode());
 
         var tidligsteUttakDato = tidligsteUttakFørTermin.filter(tft -> tft.isBefore(tidligsteUttakFørHendelseSedvane))
             .orElse(tidligsteUttakFørHendelseSedvane);

--- a/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/regelmodell/opptjeningsperiode/RegelFastsettOpptjeningsperiodeTest.java
+++ b/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/regelmodell/opptjeningsperiode/RegelFastsettOpptjeningsperiodeTest.java
@@ -71,6 +71,67 @@ class RegelFastsettOpptjeningsperiodeTest {
     }
 
     @Test
+    void mor_fødsel_uten_termin_senest_fødselsdato() {
+        // Arrange
+        var fødselsDato = LocalDate.of(2018, Month.MAY, 1);
+        var uttaksDato = LocalDate.of(2018, Month.MAY, 5);
+        var regelmodell = opprettOpptjeningsperiodeGrunnlagForMorFødsel(null, fødselsDato, uttaksDato);
+
+        // Act
+        var resultat = new OpptjeningsPeriode();
+        new RegelFastsettOpptjeningsperiode().evaluer(regelmodell, resultat);
+        // Assert
+        assertSkjæringsdato(resultat, fødselsDato);
+    }
+
+    @Test
+    void mor_fødsel_uten_termin_tidlig_uttak() {
+        // Arrange
+        var fødselsdato = LocalDate.of(2018, Month.MAY, 1);
+        var uttaksDato = LocalDate.of(2018, Month.FEBRUARY, 5);
+        var regelmodell = opprettOpptjeningsperiodeGrunnlagForMorFødsel(null, fødselsdato, uttaksDato);
+
+        // Act
+        var tidligsteLovligeUttaksdato = fødselsdato.minusWeeks(12);
+        var resultat = new OpptjeningsPeriode();
+        new RegelFastsettOpptjeningsperiode().evaluer(regelmodell, resultat);
+        // Assert
+        assertSkjæringsdato(resultat, tidligsteLovligeUttaksdato);
+    }
+
+    @Test
+    void mor_fødsel_og_termin_tidlig_uttak() {
+        // Arrange
+        var fødselsdato = LocalDate.of(2018, Month.MAY, 1);
+        var termindato = LocalDate.of(2018, Month.MAY, 8);
+        var uttaksDato = LocalDate.of(2018, Month.FEBRUARY, 5);
+        var regelmodell = opprettOpptjeningsperiodeGrunnlagForMorFødsel(termindato, fødselsdato, uttaksDato);
+
+        // Act
+        var tidligsteLovligeUttaksdato = fødselsdato.minusWeeks(12);
+        var resultat = new OpptjeningsPeriode();
+        new RegelFastsettOpptjeningsperiode().evaluer(regelmodell, resultat);
+        // Assert
+        assertSkjæringsdato(resultat, tidligsteLovligeUttaksdato);
+    }
+
+    @Test
+    void mor_fødsel_og_termin_tidlig_uttak_fødsel_etter_termin() {
+        // Arrange
+        var fødselsdato = LocalDate.of(2018, Month.MAY, 8);
+        var termindato = LocalDate.of(2018, Month.MAY, 1);
+        var uttaksDato = LocalDate.of(2018, Month.FEBRUARY, 5);
+        var regelmodell = opprettOpptjeningsperiodeGrunnlagForMorFødsel(termindato, fødselsdato, uttaksDato);
+
+        // Act
+        var tidligsteLovligeUttaksdato = termindato.minusWeeks(12);
+        var resultat = new OpptjeningsPeriode();
+        new RegelFastsettOpptjeningsperiode().evaluer(regelmodell, resultat);
+        // Assert
+        assertSkjæringsdato(resultat, tidligsteLovligeUttaksdato);
+    }
+
+    @Test
     void skalFastsetteDatoLikUttaksDatoFA() {
         // Arrange
         var omsorgsDato = LocalDate.of(2018, Month.JANUARY, 15);


### PR DESCRIPTION
Fra før: inntil 12u før termin, senest 3 uker før termin. Dersom termindato mangler: inntil 3 uker før fødsel, senest fødsel

Nå: inntil 12u før termin, senest 3 uker før termin. Dersom termindato mangler: inntil 12 uker før fødsel, senest fødsel. Dersom både fødselsdato og termindato - inntil 12 uker før den tidligste av dem,