### PR TITLE
TFP-5945 Forslag 1: automatiske revurderinger ser ikke på oppgitte ut…

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/regelmodell/medlemskap/v2/MedlemskapsvilkårGrunnlag.java
+++ b/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/regelmodell/medlemskap/v2/MedlemskapsvilkårGrunnlag.java
@@ -11,7 +11,7 @@ import no.nav.fpsak.tidsserie.LocalDateInterval;
 public record MedlemskapsvilkårGrunnlag(LocalDateInterval vurderingsperiodeBosatt, LocalDateInterval vurderingsperiodeLovligOpphold,
                                         Set<LocalDateInterval> registrertMedlemskapPerioder, Personopplysninger personopplysninger, Søknad søknad,
                                         Arbeid arbeid, LocalDate skjæringstidspunkt, LocalDate behandlingsdato,
-                                        Beløp grunnbeløp) implements VilkårGrunnlag {
+                                        Beløp grunnbeløp, RevurderingÅrsak revurderingÅrsak) implements VilkårGrunnlag {
 
     public record Søknad(Set<LocalDateInterval> utenlandsopphold) {
     }

--- a/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/regelmodell/medlemskap/v2/RevurderingÅrsak.java
+++ b/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/regelmodell/medlemskap/v2/RevurderingÅrsak.java
@@ -1,0 +1,5 @@
+package no.nav.foreldrepenger.inngangsvilkaar.regelmodell.medlemskap.v2;
+
+public enum RevurderingÅrsak {
+    MANUELL, ANNEN
+}

--- a/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/regelmodell/medlemskap/v2/SjekkOmOppgittUtenlandsopphold.java
+++ b/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/regelmodell/medlemskap/v2/SjekkOmOppgittUtenlandsopphold.java
@@ -1,8 +1,12 @@
 package no.nav.foreldrepenger.inngangsvilkaar.regelmodell.medlemskap.v2;
 
+import java.util.Objects;
+import java.util.Set;
+
 import no.nav.fpsak.nare.doc.RuleDocumentation;
 import no.nav.fpsak.nare.evaluation.Evaluation;
 import no.nav.fpsak.nare.specification.LeafSpecification;
+import no.nav.fpsak.tidsserie.LocalDateInterval;
 
 @RuleDocumentation(SjekkOmOppgittUtenlandsopphold.ID)
 class SjekkOmOppgittUtenlandsopphold extends LeafSpecification<MedlemskapsvilkårMellomregning> {
@@ -16,10 +20,18 @@ class SjekkOmOppgittUtenlandsopphold extends LeafSpecification<Medlemskapsvilkå
 
     @Override
     public Evaluation evaluate(MedlemskapsvilkårMellomregning mellomregning) {
-        if (!mellomregning.grunnlag().søknad().utenlandsopphold().isEmpty()) {
+        var utenlandsopphold = mellomregning.grunnlag().søknad().utenlandsopphold();
+        if (harAvvik(utenlandsopphold, mellomregning.grunnlag().revurderingÅrsak())) {
             mellomregning.addAvvik(MedlemskapAvvik.BOSATT_UTENLANDSOPPHOLD);
         }
         return ja();
+    }
+
+    static boolean harAvvik(Set<LocalDateInterval> utenlandsopphold, RevurderingÅrsak revurderingÅrsak) {
+        if (utenlandsopphold.isEmpty()) {
+            return false;
+        }
+        return revurderingÅrsak == null || Objects.equals(RevurderingÅrsak.MANUELL, revurderingÅrsak);
     }
 
 }

--- a/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/regelmodell/medlemskap/v2/MedlemskapsvilkårTest.java
+++ b/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/regelmodell/medlemskap/v2/MedlemskapsvilkårTest.java
@@ -33,7 +33,7 @@ class MedlemskapsvilkårTest {
         var behandlingsdato = of(2024, 1, 1);
         var grunnbeløp = new MedlemskapsvilkårGrunnlag.Beløp(BigDecimal.valueOf(1000));
         var grunnlag = new MedlemskapsvilkårGrunnlag(vurderingsperiodeBosatt, vurderingsperiodeLovligOpphold, registrertMedlemskapPerioder,
-            personopplysninger, søknad, arbeid, skjæringstidspunkt, behandlingsdato, grunnbeløp);
+            personopplysninger, søknad, arbeid, skjæringstidspunkt, behandlingsdato, grunnbeløp, null);
         var regelEvalueringResultat = InngangsvilkårRegler.medlemskap(grunnlag);
 
         assertThat(regelEvalueringResultat.merknad().regelUtfallMerknad()).isEqualTo(RegelUtfallMerknad.RVM_1025);
@@ -60,7 +60,7 @@ class MedlemskapsvilkårTest {
             Set.of(new MedlemskapsvilkårGrunnlag.Arbeid.Inntekt(new LocalDateInterval(of(2023, 12, 1), of(2023, 12, 31)), grunnbeløp)));
         var behandlingsdato = of(2024, 1, 1);
         var grunnlag = new MedlemskapsvilkårGrunnlag(vurderingsperiodeBosatt, vurderingsperiodeLovligOpphold, Set.of(),
-            personopplysninger, søknad, arbeid, skjæringstidspunkt, behandlingsdato, grunnbeløp);
+            personopplysninger, søknad, arbeid, skjæringstidspunkt, behandlingsdato, grunnbeløp, null);
         var regelEvalueringResultat = InngangsvilkårRegler.medlemskap(grunnlag);
 
         assertThat(regelEvalueringResultat.merknad()).isNull();

--- a/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/regelmodell/medlemskap/v2/SjekkOmOppgittUtenlandsoppholdTest.java
+++ b/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/regelmodell/medlemskap/v2/SjekkOmOppgittUtenlandsoppholdTest.java
@@ -1,0 +1,26 @@
+package no.nav.foreldrepenger.inngangsvilkaar.regelmodell.medlemskap.v2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import no.nav.fpsak.tidsserie.LocalDateInterval;
+
+class SjekkOmOppgittUtenlandsoppholdTest {
+
+    @Test
+    void utenlandsopphold_og_ingen_revurderingÅrsak() {
+        assertThat(SjekkOmOppgittUtenlandsopphold.harAvvik(Set.of(), null)).isFalse();
+        assertThat(SjekkOmOppgittUtenlandsopphold.harAvvik(Set.of(new LocalDateInterval(LocalDate.now(), LocalDate.now())), null)).isTrue();
+    }
+
+    @Test
+    void utenlandsopphold_og_revurderingÅrsak() {
+        var utenlandsopphold = Set.of(new LocalDateInterval(LocalDate.now(), LocalDate.now()));
+        assertThat(SjekkOmOppgittUtenlandsopphold.harAvvik(utenlandsopphold, RevurderingÅrsak.ANNEN)).isFalse();
+        assertThat(SjekkOmOppgittUtenlandsopphold.harAvvik(utenlandsopphold, RevurderingÅrsak.MANUELL)).isTrue();
+    }
+}


### PR DESCRIPTION
…enlandsopphold

Ta inn revurderingårsak slik som jeg gjør her?
Eller bare å la være å sende inn periodene i grunnlagbyggeren i fpsak?
Hva tenker folk er best?

Jeg tenker at det er mest oversiktlig/sporbart at det ligger i selve fp-inngangsvilkår reglene