### PR TITLE
fix: revert fp-tidsserie til 2.7.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>no.nav.fpsak.tidsserie</groupId>
             <artifactId>fpsak-tidsserie</artifactId>
-            <version>2.7.5</version>
+            <version>2.7.4</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
fp-tidsserie 2.7.5 introduserte en bug i LocalDateTimeline.combine()/ intersection() (KnekkpunktIterator) der kombinering av to tidslinjer som begge har et segment åpent til LocalDate.MAX gir feil eller tomt resultat for JoinStyle INNER_JOIN, RIGHT_JOIN, CROSS_JOIN og LEFT_JOIN.

Reverter til siste kjente gode versjon inntil fikset er verifisert oppstrøms.